### PR TITLE
Revert erroneous 'encode' calls added

### DIFF
--- a/afl-cov
+++ b/afl-cov
@@ -803,10 +803,7 @@ def is_afl_fuzz_running(cargs):
         pid = get_running_pid(stats_file, rb"fuzzer_pid\s+\:\s+(\d+)")
     else:
         for p in os.listdir(cargs.afl_fuzzing_dir):
-            stats_file = "%s/%s/fuzzer_stats" % (
-                cargs.afl_fuzzing_dir.encode(),
-                p.encode(),
-            )
+            stats_file = "%s/%s/fuzzer_stats" % ( cargs.afl_fuzzing_dir, p)
             if os.path.exists(stats_file):
                 # allow a single running AFL instance in parallel mode
                 # to mean that AFL is running (and may be generating


### PR DESCRIPTION
During py3 fixes, the two `encode` calls were added.
It turns out, at least for me, that addition got afl-cov
stuck on the sleep loop, never finding "fuzzer_stats"
files.

Printing the resulting path: I get something like:
`<FUZZ_DIR_PATH>/sync_dir'/b'<FUZZER_NAME>'/fuzzer_stats`

Removing the two `encode` calls fixes this.

Let me know if you need more details to reproduce!