### PR TITLE
Allow keyboard interrupt during live sessions

### DIFF
--- a/afl-cov
+++ b/afl-cov
@@ -285,7 +285,15 @@ def process_afl_test_cases(cargs: argparse.Namespace) -> bool:
                         cov_paths["log_file"],
                         cargs,
                     )
-                    time.sleep(cargs.sleep)
+                    try:
+                        time.sleep(cargs.sleep)
+                    except KeyboardInterrupt:
+                        log(
+                            b"[+] Stopping live collection due to user interrupt",
+                            cov_paths["log_file"],
+                            cargs,
+                        )
+                        break
                     continue
             else:
                 logr(


### PR DESCRIPTION
Instead of abruptly terminating the collection session,
have keyboard interrupts during sleep just break the
loop, allowing for final cleanups and output generation