### PR TITLE
Add a subprocess.Popen timeout when possible

### DIFF
--- a/afl-cov
+++ b/afl-cov
@@ -856,7 +856,7 @@ def run_cmd(
     collect: int,
     aflrun: bool,
     fn: str,
-    timeout: Optional[int] = None,
+    timeout: Optional[str] = None,
 ) -> Tuple[int, List[bytes]]:
     out = []
 
@@ -877,9 +877,22 @@ def run_cmd(
     if timeout:
         cmd = "timeout -s KILL %s %s" % (timeout, cmd)
 
-    exit_code = subprocess.call(
-        cmd, stdin=None, stdout=fh, stderr=subprocess.STDOUT, shell=True
-    )
+    # If timeout is in seconds, add an extra layer of timeout
+    # the timeout linux command failed me on several occasions
+    sp_timeout = int(timeout) * 2 if timeout and timeout.isdigit() else None
+
+    try:
+        exit_code = subprocess.call(
+            cmd, stdin=None, stdout=fh, stderr=subprocess.STDOUT, shell=True,
+            timeout=sp_timeout
+        )
+    except subprocess.TimeoutExpired:
+        if cargs.verbose:
+            if log_file:
+                logr(b"    CMD: %s timedout: %s" % (cmd.encode(), str(ex)), log_file, cargs)
+            else:
+                print("    CMD: %s timedout: %s" % (cmd, str(ex)))
+        exit_code = -1
 
     fh.close()
 


### PR DESCRIPTION
The linux timeout command seems to fail terminating processes
occasionally, so when possible without breaking the interface I've added
a subprocess.Popen timeout (to be double the linux timeout) as a backup
timeout.

This is a bit hackish but has been useful for me.