### PR TITLE
1)timeout "-T" option fix. 2)Non-UTF characters in filenames now allowed.

### DIFF
--- a/afl-cov
+++ b/afl-cov
@@ -865,6 +865,9 @@ def run_cmd(
     else:
         fh = open(os.devnull, "wb")
 
+    if timeout:
+        cmd = "timeout -s KILL %s %s" % (timeout, cmd)
+
     if aflrun is True and len(fn) > 0:
         cmd = "cat " + fn + " | " + cmd
 
@@ -873,9 +876,6 @@ def run_cmd(
             logr(b"    CMD: %s" % cmd.encode(), log_file, cargs)
         else:
             print("    CMD: %s" % cmd)
-
-    if timeout:
-        cmd = "timeout -s KILL %s %s" % (timeout, cmd)
 
     exit_code = subprocess.call(
         cmd, stdin=None, stdout=fh, stderr=subprocess.STDOUT, shell=True

--- a/afl-cov
+++ b/afl-cov
@@ -186,7 +186,7 @@ def process_afl_test_cases(cargs: argparse.Namespace) -> bool:
                 logr(
                     b"[+] AFL test case: %s (%d / %d), cycle: %d"
                     % (
-                        os.path.basename(f).encode(),
+                        os.path.basename(f).encode(errors="namereplace"),
                         num_files,
                         len(afl_files),
                         curr_cycle,
@@ -873,7 +873,7 @@ def run_cmd(
 
     if cargs.verbose:
         if log_file:
-            logr(b"    CMD: %s" % cmd.encode(), log_file, cargs)
+            logr(b"    CMD: %s" % cmd.encode(errors="namereplace"), log_file, cargs)
         else:
             print("    CMD: %s" % cmd)
 


### PR DESCRIPTION
Hello! I have 2 bugs&bugfixes.

1) "timeout" applies after "cat", so "my_app @@", become "timeout cat filename | my_app @@".
cat is usually very quick, so time out options now just don't work. This fix changes --verbose output too, now full command line will be printed.

2) Problem with ".encode()". I tried fuzzing with "bash", and it shows very interesting behaviour. Sometimes files have strange names and produce strange errors. So afl-cov should deal with non-UTF names of files.
And everything is ok, except encoding filename to UTF for logfile. Fixes it with replacing  the unencodable character by its name, using errors="namereplace".

I hope it will help. Thank you!