### PR TITLE
Fix exponential time growth with coverage of parallel runs

### DIFF
--- a/afl-cov
+++ b/afl-cov
@@ -285,6 +285,8 @@ def process_afl_test_cases(cargs: argparse.Namespace) -> bool:
                 if do_break:
                     break
 
+            new_files = []
+
         if cargs.live:
             if is_afl_fuzz_running(cargs):
                 if not len(new_files):

--- a/afl-cov
+++ b/afl-cov
@@ -197,7 +197,7 @@ def process_afl_test_cases(cargs: argparse.Namespace) -> bool:
                     % (
                         os.path.basename(f).encode(errors="namereplace"),
                         num_files,
-                        len(afl_files),
+                        len(new_files),
                         curr_cycle,
                     ),
                     cov_paths["log_file"],


### PR DESCRIPTION
Currently, when calculating coverage for a parallelized fuzzing run, each new testcase folder that is iterated over by afl-cov causes coverage to be recalculated for the tests in all of the previous folders it has already calculated coverage for. This leads the time taken to calculate coverage to grow exponentially with the number of cores used during the fuzzing run.