### PR TITLE
Fixing * escape

### DIFF
--- a/afl-cov
+++ b/afl-cov
@@ -1477,7 +1477,7 @@ def parse_cmdline() -> argparse.Namespace:
         "--lcov-exclude-pattern",
         type=str,
         help="Set exclude pattern for lcov results",
-        default="/usr/include/\*",
+        default=r"/usr/include/*",
     )
     p.add_argument(
         "--func-search", type=str, help="Search for coverage of a specific function"


### PR DESCRIPTION
When running `afl-cov` without `--lcov-exclude-pattern`, it will use `/usr/include/*` by default. 
However it seems that * isn't a valid special character, therefore the escape will throw the following python exception:  `afl-cov:1480: SyntaxWarning: invalid escape sequence '\*'`

I've tested it on Python 3.x and 2.x. The fix is just to include a `r`(aw) python strings for a correct parsing