### PR TITLE
Use shell to run the command if also using a timeout

### DIFF
--- a/afl-cov
+++ b/afl-cov
@@ -35,6 +35,7 @@ import re
 import signal
 import sys
 import time
+import shlex
 from shutil import rmtree
 from shutil import copyfile
 from sys import argv
@@ -877,7 +878,7 @@ def run_cmd(
         fh = open(os.devnull, "wb")
 
     if timeout:
-        cmd = "timeout -s KILL %s %s" % (timeout, cmd)
+        cmd = "timeout -s KILL %s sh -c %s" % (timeout, shlex.quote(cmd))
 
     if aflrun is True and len(fn) > 0:
         cmd = "cat " + fn + " | " + cmd


### PR DESCRIPTION
The problem with `timeout %s %s` is that with suggested command from the docs  `LD_LIBRARY_PATH=some/path bin/exe`
it quite obviously fails, because LD_LIBRARY_PATH=some/path is not a name of an executable file. To actually have it working, you need to interpret that syntax in a shell, which this change does. 

This patch retains that the command line is shell-interpreted (ie. wildcard-expanded, variable-expanded) each time.

Also, it probably works only on unix.