### PR TITLE
Be more forgiving when lcov returns errors

### DIFF
--- a/afl-cov
+++ b/afl-cov
@@ -685,7 +685,7 @@ def get_cycle_num(id_num: int, cargs: argparse.Namespace) -> int:
 
 def lcov_gen_coverage(cov_paths: CovPathsDictType, cargs: argparse.Namespace):
 
-    lcov_opts = ""
+    lcov_opts = " --ignore-errors inconsistent "
     if cargs.enable_branch_coverage:
         lcov_opts += " --rc lcov_branch_coverage=1"
     if cargs.follow:


### PR DESCRIPTION
afl-cov failed to collect coverage in a C++ project, reporting that lcov failed due to inconsistencies. This patch silences that error. The inconsistencies probably originated on a line which defined a lambda, which never ran, but the line defining it did and lcov got a bit confused.

An alternative fix would be to introduce user-supplied arguments to lcov.